### PR TITLE
Fix all instances of Raster.open

### DIFF
--- a/BESS_JPL/carbon_water_fluxes.py
+++ b/BESS_JPL/carbon_water_fluxes.py
@@ -12,25 +12,6 @@ from .soil_energy_balance import soil_energy_balance
 
 PASSES = 1
 
-
-def load_ball_berry_intercept_C3(self, geometry: RasterGeometry) -> Raster:
-    filename = join(abspath(dirname(__file__)), "ball_berry_intercept_C3.tif")
-    image = rt.Raster.open(filename, geometry=geometry, resampling=self.resampling)
-
-    return image
-
-def load_ball_berry_slope_C3(self, geometry: RasterGeometry) -> Raster:
-    filename = join(abspath(dirname(__file__)), "ball_berry_slope_C3.tif")
-    image = rt.Raster.open(filename, geometry=geometry, resampling=self.resampling)
-
-    return image
-
-def load_ball_berry_slope_C4(self, geometry: RasterGeometry) -> Raster:
-    filename = join(abspath(dirname(__file__)), "ball_berry_slope_C4.tif")
-    image = rt.Raster.open(filename, geometry=geometry, resampling=self.resampling)
-
-    return image
-
 def carbon_water_fluxes(
         canopy_temperature_K: np.ndarray,  # canopy temperature in Kelvin
         soil_temperature_K: np.ndarray,  # soil temperature in Kelvin

--- a/BESS_JPL/load_C4_fraction.py
+++ b/BESS_JPL/load_C4_fraction.py
@@ -3,8 +3,12 @@ from os.path import join, abspath, dirname
 import rasters as rt
 from rasters import Raster, RasterGeometry
 
+import numpy as np
+
 def load_C4_fraction(geometry: RasterGeometry = None, resampling: str = "nearest") -> Raster:
     filename = join(abspath(dirname(__file__)), "C4_fraction.tif")
-    image = Raster.open(filename, geometry=geometry, resampling=resampling)
+    image = Raster.open(filename, geometry=geometry, resampling=resampling, nodata=np.nan)
+    image = rt.clip(image, 0, 100)
+    # TODO: scale C4_fraction to be within 0 and 1?
 
     return image

--- a/BESS_JPL/load_NDVI_maximum.py
+++ b/BESS_JPL/load_NDVI_maximum.py
@@ -3,8 +3,10 @@ from os.path import join, abspath, dirname
 import rasters as rt
 from rasters import Raster, RasterGeometry
 
+import numpy as np
+
 def load_NDVI_maximum(geometry: RasterGeometry = None, resampling: str = "nearest") -> Raster:
     filename = join(abspath(dirname(__file__)), "NDVI_maximum.tif")
-    image = Raster.open(filename, geometry=geometry, resampling=resampling)
+    image = Raster.open(filename, geometry=geometry, resampling=resampling, nodata=np.nan)
 
     return image

--- a/BESS_JPL/load_NDVI_minimum.py
+++ b/BESS_JPL/load_NDVI_minimum.py
@@ -3,8 +3,10 @@ from os.path import join, abspath, dirname
 import rasters as rt
 from rasters import Raster, RasterGeometry
 
+import numpy as np
+
 def load_NDVI_minimum(geometry: RasterGeometry = None, resampling: str = "nearest") -> Raster:
     filename = join(abspath(dirname(__file__)), "NDVI_minimum.tif")
-    image = Raster.open(filename, geometry=geometry, resampling=resampling)
+    image = Raster.open(filename, geometry=geometry, resampling=resampling, nodata=np.nan)
 
     return image

--- a/BESS_JPL/load_ball_berry_slope_C3.py
+++ b/BESS_JPL/load_ball_berry_slope_C3.py
@@ -5,6 +5,6 @@ from rasters import Raster, RasterGeometry
 
 def load_ball_berry_slope_C3(geometry: RasterGeometry = None, resampling: str = "nearest") -> Raster:
     filename = join(abspath(dirname(__file__)), "ball_berry_slope_C3.tif")
-    image = Raster.open(filename, geometry=geometry, resampling="nearest")
+    image = Raster.open(filename, geometry=geometry, resampling=resampling)
 
     return image

--- a/BESS_JPL/load_ball_berry_slope_C4.py
+++ b/BESS_JPL/load_ball_berry_slope_C4.py
@@ -5,6 +5,6 @@ from rasters import Raster, RasterGeometry
 
 def load_ball_berry_slope_C4(geometry: RasterGeometry = None, resampling: str = "nearest") -> Raster:
     filename = join(abspath(dirname(__file__)), "ball_berry_slope_C4.tif")
-    image = Raster.open(filename, geometry=geometry, resampling="nearest")
+    image = Raster.open(filename, geometry=geometry, resampling=resampling)
 
     return image

--- a/BESS_JPL/load_kn.py
+++ b/BESS_JPL/load_kn.py
@@ -5,6 +5,6 @@ from rasters import Raster, RasterGeometry
 
 def load_kn(geometry: RasterGeometry = None, resampling: str = "nearest") -> Raster:
     filename = join(abspath(dirname(__file__)), "kn.tif")
-    image = Raster.open(filename, geometry=geometry, resampling="nearest")
+    image = Raster.open(filename, geometry=geometry, resampling=resampling)
 
     return image

--- a/BESS_JPL/load_peakVCmax_C3.py
+++ b/BESS_JPL/load_peakVCmax_C3.py
@@ -3,8 +3,10 @@ from os.path import join, abspath, dirname
 import rasters as rt
 from rasters import Raster, RasterGeometry
 
+import numpy as np
+
 def load_peakVCmax_C3(geometry: RasterGeometry = None, resampling: str = "nearest") -> Raster:
     filename = join(abspath(dirname(__file__)), "peakVCmax_C3.tif")
-    image = Raster.open(filename, geometry=geometry, resampling="nearest")
+    image = Raster.open(filename, geometry=geometry, resampling=resampling, nodata=np.nan)
 
     return image

--- a/BESS_JPL/load_peakVCmax_C4.py
+++ b/BESS_JPL/load_peakVCmax_C4.py
@@ -3,8 +3,10 @@ from os.path import join, abspath, dirname
 import rasters as rt
 from rasters import Raster, RasterGeometry
 
+import numpy as np
+
 def load_peakVCmax_C4(geometry: RasterGeometry = None, resampling: str = "nearest") -> Raster:
     filename = join(abspath(dirname(__file__)), "peakVCmax_C4.tif")
-    image = Raster.open(filename, geometry=geometry, resampling="nearest")
+    image = Raster.open(filename, geometry=geometry, resampling=resampling, nodata=np.nan)
 
     return image


### PR DESCRIPTION
The two changes that I made were:
1. add back a missing hard-coded nodata parameter
2. Fix the method to use the resampling parameter

While making these changes, I also noticed that `C4_fraction.tif` is likely being misused. It is loaded as a value between 0-100, but the `interpolate_C4` method treats it as if it was between 0 and 1.

Closes #54 