### PR TITLE
Two more small BESS fixes

### DIFF
--- a/BESS_JPL/LAI_from_NDVI.py
+++ b/BESS_JPL/LAI_from_NDVI.py
@@ -23,7 +23,6 @@ def LAI_from_NDVI(
         Union[Raster, np.ndarray]: Converted LAI data.
     """
     fIPAR = rt.clip(NDVI - 0.05, min_fIPAR, max_fIPAR)
-    fIPAR = np.where(fIPAR == 0, np.nan, fIPAR)
     LAI = rt.clip(-np.log(1 - fIPAR) * (1 / KPAR), min_LAI, max_LAI)
 
     return LAI

--- a/BESS_JPL/model.py
+++ b/BESS_JPL/model.py
@@ -185,7 +185,12 @@ def BESS_JPL(
                 logger.warning(f"Variable '{name}' has a different size: {size} (expected: {reference_size}).")
 
     # check if any of the FLiES outputs are not given
-    if None in (Rg, VISdiff, VISdir, NIRdiff, NIRdir, UV, albedo_visible, albedo_NIR):
+    flies_variables = [Rg, VISdiff, VISdir, NIRdiff, NIRdir, UV, albedo_visible, albedo_NIR]
+    flies_variables_missing = False
+    for variable in flies_variables:
+        if variable is None:
+            flies_variables_missing = True
+    if flies_variables_missing:
         # load cloud optical thickness if not provided
         if COT is None:
             COT = GEOS5FP_connection.COT(time_UTC=time_UTC, geometry=geometry, resampling=resampling)


### PR DESCRIPTION
@gregory-halverson @gregory-halverson-jpl to decide if these two fixes are beneficial.

Fix 1 prevents FLiES from being run a second time unnecessarily in L3T_L4T_JET. It turns out that `None in (tuple)` doesn't work.

Fix 2 is to avoid what seems to be an unnecessary introduction of NaNs into the LAI variable. I can't understand why this check was added, and there doesn't seem to be any explanation given in the commit history. This line didn't exist in Collection 2, so I would bias towards removing it.